### PR TITLE
LogisticRegression() -> LogisticRegression(solver='liblinear')

### DIFF
--- a/ipython/Labs_Student/Lab_Sklearn_Magic.ipynb
+++ b/ipython/Labs_Student/Lab_Sklearn_Magic.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "In this lab we'll demonstrate several common techniques and helpful tools used in a model building process:\n",
     "\n",
@@ -31,7 +29,10 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [
     {
@@ -81,7 +82,10 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -109,7 +113,10 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [
     {
@@ -125,7 +132,7 @@
     "param_grid_lr = {'C':[10**i for i in range(-3, 3)], 'penalty':['l1', 'l2']}\n",
     "\n",
     "#2nd, call the GridSearchCV class, use LogisticRegression and 'roc_auc' for scoring\n",
-    "lr_grid_search = GridSearchCV(LogisticRegression(), param_grid_lr, cv = kfolds, scoring = 'roc_auc') \n",
+    "lr_grid_search = GridSearchCV(LogisticRegression(solver='liblinear'), param_grid_lr, cv = kfolds, scoring = 'roc_auc') \n",
     "lr_grid_search.fit(X, Y)\n",
     "\n",
     "#3rd, get the score of the best model and print it\n",
@@ -137,7 +144,10 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [
     {
@@ -170,7 +180,10 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [
     {
@@ -190,7 +203,7 @@
     "#The last step should be an estimator.\n",
     "\n",
     "steps = [('scaler', StandardScaler()),\n",
-    "         ('lr', LogisticRegression())]\n",
+    "         ('lr', LogisticRegression(solver='liblinear'))]\n",
     "\n",
     "#Now set up the pipeline\n",
     "pipeline = Pipeline(steps)\n",
@@ -213,7 +226,10 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [
     {
@@ -246,7 +262,10 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [
     {
@@ -267,7 +286,7 @@
     "\n",
     "steps_poly = [('polyfeat', PolynomialFeatures()),\n",
     "         ('scaler', StandardScaler()),\n",
-    "         ('lr', LogisticRegression())]\n",
+    "         ('lr', LogisticRegression(solver='liblinear'))]\n",
     "\n",
     "#Now set up the pipeline\n",
     "pipeline_poly = Pipeline(steps_poly)\n",
@@ -290,7 +309,10 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [
     {
@@ -327,7 +349,10 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [
     {
@@ -374,7 +399,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": []
@@ -383,7 +411,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": []
@@ -406,9 +437,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
What: Adding solver='liblinear' in the LogisticRegression().

Why: The default solver 'lbfgs' does not support 'l1' penalty, and hyper-parameter search over the type of penalty returns ValueError.